### PR TITLE
patch for Windows MSVC from W32TeX

### DIFF
--- a/src/ppload.c
+++ b/src/ppload.c
@@ -1,6 +1,11 @@
 
 #include "pplib.h"
 
+#ifdef _WIN32 /* --ak */
+extern FILE *ppu8open(const char *filename, const char *mode);
+#define fopen ppu8open
+#endif /* _WIN32 --ak */
+
 const char * ppobj_kind[] = { "none", "null", "bool", "integer", "number", "name", "string", "array", "dict", "stream", "ref" };
 
 #define ignored_char(c) (c == 0x20 || c == 0x0A || c == 0x0D || c == 0x09 || c == 0x00)

--- a/src/pptest1.c
+++ b/src/pptest1.c
@@ -61,6 +61,10 @@ static int usage (const char *argv0)
   return 0;
 }
 
+#ifdef _WIN32 /* --ak */
+#include <fcntl.h>
+#endif /* _WIN32 --ak */
+
 int main (int argc, const char **argv)
 {
   const char *filepath;
@@ -68,6 +72,10 @@ int main (int argc, const char **argv)
   ppdoc *pdf;
   const void *data;
   size_t size;
+
+#ifdef _WIN32 /* --ak */
+  _setmode(fileno(stdout), _O_BINARY);
+#endif /* _WIN32 --ak */
 
   if (argc < 2)
     return usage(argv[0]);

--- a/src/pptest2.c
+++ b/src/pptest2.c
@@ -36,6 +36,10 @@ static void log_callback (const char *message, void *alien)
   fprintf((FILE *)alien, "\nooops: %s\n", message);
 }
 
+#ifdef _WIN32 /* --ak */
+#include <fcntl.h>
+#endif /* _WIN32 --ak */
+
 int main (int argc, const char **argv)
 {
   const char *filepath;
@@ -53,6 +57,10 @@ int main (int argc, const char **argv)
   ppobj *obj;
   ppname *op;
   size_t operators;
+
+#ifdef _WIN32 /* --ak */
+  _setmode(fileno(stdout), _O_BINARY);
+#endif /* _WIN32 --ak */
 
   if (argc < 2)
     return usage(argv[0]);

--- a/src/pptest3.c
+++ b/src/pptest3.c
@@ -76,6 +76,10 @@ static void check_stream_chunks (ppstream *stream)
 
 #define USE_BUFFERS_POOL 1
 
+#ifdef _WIN32 /* --ak */
+#include <fcntl.h>
+#endif /* _WIN32 --ak */
+
 int main (int argc, const char **argv)
 {
   const char *filepath;
@@ -86,6 +90,10 @@ int main (int argc, const char **argv)
   size_t xi;
   ppuint refnum;
   ppref *ref;
+
+#ifdef _WIN32 /* --ak */
+  _setmode(fileno(stdout), _O_BINARY);
+#endif /* _WIN32 --ak */
 
   if (argc < 2)
     return usage(argv[0]);

--- a/src/util/utilmd5.c
+++ b/src/util/utilmd5.c
@@ -61,6 +61,11 @@
 
 #include "utilmd5.h"
 
+#ifdef _WIN32 /* --ak */
+extern FILE *ppu8open(const char *filename, const char *mode);
+#define fopen ppu8open
+#endif /* _WIN32 --ak */
+
 #undef BYTE_ORDER /* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
 #  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)

--- a/src/util/utilsha.c
+++ b/src/util/utilsha.c
@@ -38,6 +38,11 @@
 //#include <assert.h> /* assert() */
 #include "utilsha.h"
 
+#ifdef _WIN32 /* --ak */
+extern FILE *ppu8open(const char *filename, const char *mode);
+#define fopen ppu8open
+#endif /* _WIN32 --ak */
+
 /*
  * UNROLLED TRANSFORM LOOP NOTE:
  * You can define SHA2_UNROLL_TRANSFORM to use the unrolled transform


### PR DESCRIPTION
I heard Akira Kakuto-san have decided to complete his contribution to the TeX community and have closed w32tex.org.
This pull request is the patch derived by @aminophen for Windows MS Visual C from Kakuto-san's W32TeX source code.
I expect the patch is also useful for other compilers mingw and cygwin on Windows.
I would like you to consider pulling it in the master.

The patch treats:
- Unicode file names
- path separator
- UNC
- file open by binary mode
